### PR TITLE
Scan all html files instead of just those named component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 coverage
 .DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ npm install --save-dev @blackbaud/skyux-builder-resource-linter
 skyux lint-resources
 ```
 
+## Glossary
+
+- **Missing keys** - Keys that were determined to be used somewhere in the application but that don't have a matching entry in a resource file.
+- **Potentially Unused Keys** - Keys whose use could not be determined but that might still be required by the application. Manually verify that the keys are not used before removal.
+- **Non-standard Keys** - Keys present in a method that consumes a resource key but that appear to be a reference to the key rather than the key itself.
+
 ## Development
 
 ### Testing

--- a/src/lint-resources.js
+++ b/src/lint-resources.js
@@ -9,24 +9,27 @@ const tsResourcesServiceLookupRegex = /\S*(?=:\s?Sky(?:App|Lib)ResourcesService)
 
 function lintResources(argv, config) {
     // Get all file paths
-    const htmlFilePaths = glob.sync('./src/app/**/*component.html');
+    const htmlFilePaths = glob.sync('./src/app/**/*.html');
     const tsFilePaths = glob.sync('./src/app/**/!(*.spec|*.mock).ts')
     const resourceFilePaths = glob.sync('./src/assets/locales/*.json');
+
     // Get resource keys, files, and file resource references
     const keys = getResourceStringKeys(resourceFilePaths);
     const htmlFiles = getFiles(htmlFilePaths);
     const tsFiles = getFiles(tsFilePaths);
     const htmlRefs = getHtmlReferences(htmlFiles);
     const tsRefs = getTSReferences(tsFiles);
+
     // Get results
     const unusedKeys = findUnusedKeysInResourceFiles(keys, htmlFiles.concat(tsFiles));
     const missingKeys = findMissingKeysInResourceFiles(keys, htmlRefs.concat(tsRefs));
+
     // Log results
-    console.log('Missing Keys:');
+    console.log('Missing Keys');
     console.table(missingKeys.missing);
-    console.log('Non Standard Keys:');
+    console.log('Non-standard Keys');
     console.table(missingKeys.nonStandard);
-    console.log('Unused Keys:');
+    console.log('Potentially Unused Keys');
     console.table(unusedKeys);
 }
 

--- a/src/lint-resources.spec.js
+++ b/src/lint-resources.spec.js
@@ -12,8 +12,8 @@ describe('Lint Resources', () => {
         mock('glob', {
             sync: (path) => {
                 switch (path) {
-                    case './src/app/**/*component.html':
-                        return ['./src/app/test/test.component.html'];
+                    case './src/app/**/*.html':
+                        return ['./src/app/test/test.html'];
                     case './src/app/**/!(*.spec|*.mock).ts':
                         return ['./src/app/test/test.ts'];
                     case './src/assets/locales/*.json':
@@ -28,7 +28,7 @@ describe('Lint Resources', () => {
                 return testJSON;
             },
             readFileSync: (path) => {
-                if (path === './src/app/test/test.component.html') {
+                if (path === './src/app/test/test.html') {
                     return testHTML;
                 } else {
                     return testTS;
@@ -51,7 +51,7 @@ describe('Lint Resources', () => {
 
         // Missing keys
         expect(results[0]).toEqual([
-            { resourceFileName: 'test.json', fileName: 'test.component.html', key: 'missing_key' },
+            { resourceFileName: 'test.json', fileName: 'test.html', key: 'missing_key' },
             { resourceFileName: 'test.json', fileName: 'test.ts', key: 'test_key_missing' },
             { resourceFileName: 'test.json', fileName: 'test.ts', key: 'test_key_with_params_missing' },
             { resourceFileName: 'test.json', fileName: 'test.ts', key: 'lib_key_missing' },
@@ -60,8 +60,8 @@ describe('Lint Resources', () => {
 
         // Non-standard keys
         expect(results[1]).toEqual([
-            { resourceFileName: 'test.json', fileName: 'test.component.html', key: 'methodKey()' },
-            { resourceFileName: 'test.json', fileName: 'test.component.html', key: 'propertyKey' },
+            { resourceFileName: 'test.json', fileName: 'test.html', key: 'methodKey()' },
+            { resourceFileName: 'test.json', fileName: 'test.html', key: 'propertyKey' },
             { resourceFileName: 'test.json', fileName: 'test.ts', key: 'nonStandardKey' },
             { resourceFileName: 'test.json', fileName: 'test.ts', key: 'nonStandardKey,param1' }
         ]);
@@ -88,7 +88,7 @@ describe('Lint Resources', () => {
                 return testJSON;
             },
             readFileSync: (path) => {
-                if (path === './src/app/test/test.component.html') {
+                if (path === './src/app/test/test.html') {
                     throw err;
                 } else {
                     return testTS;
@@ -98,7 +98,7 @@ describe('Lint Resources', () => {
         lintResources = mock.reRequire('./lint-resources');
         spyOn(console, 'error');
         lintResources([], undefined);
-        expect(console.error).toHaveBeenCalledWith('Problem fetching file at path ./src/app/test/test.component.html', err);
+        expect(console.error).toHaveBeenCalledWith('Problem fetching file at path ./src/app/test/test.html', err);
     });
 
     it('should handle empty parameters', () => {


### PR DESCRIPTION
Keys were being flagged as unused when they were used in files like `index.html`.

Also, clarify language about what each resource key means.